### PR TITLE
Manuscript-import foundations: 'import' upload context + batch entities

### DIFF
--- a/apps/api/src/lib/membership.ts
+++ b/apps/api/src/lib/membership.ts
@@ -77,6 +77,7 @@ export function getSizeLimits(tier: MembershipTier): Record<string, number> {
     editor: 10 * 1024 * 1024,  // 10 MB
     avatar: 5 * 1024 * 1024,   // 5 MB
     map: 50 * 1024 * 1024,     // 50 MB
+    import: 25 * 1024 * 1024,  // 25 MB — manuscript import source (docx/epub/pdf/etc.)
   }
 
   if (tier === 'supporter') {

--- a/apps/api/src/routes/entities.ts
+++ b/apps/api/src/routes/entities.ts
@@ -150,6 +150,17 @@ const EntityUpdateSchema = EntityCreateSchema.extend({
   expectedVersion: z.number().int().positive().optional()
 })
 
+const EntityBatchCreateSchema = z.object({
+  collection: z.string()
+    .min(1, 'Collection name required')
+    .max(100, 'Collection name too long')
+    .regex(/^[a-zA-Z0-9_-]+$/, 'Collection name contains invalid characters'),
+  projectId: z.string().uuid('Invalid project ID format'),
+  items: z.array(z.record(z.string(), z.any()))
+    .min(1, 'At least one item required')
+    .max(500, 'Batch size capped at 500 items')
+})
+
 const entitiesPlugin: FastifyPluginAsync = async (fastify) => {
 
   // Query entities from a collection (requires project ownership)
@@ -615,6 +626,118 @@ const entitiesPlugin: FastifyPluginAsync = async (fastify) => {
       fastify.log.error(error)
       return reply.status(500).send({
         error: 'Failed to delete entity',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      })
+    }
+  })
+
+  // Homogeneous batch create — all items go into the same collection in the
+  // same project. The whole batch lands atomically (transaction); any insert
+  // failing rolls everything back. Use POST /entities/batch/atomic when you
+  // need mixed create/update/delete operations.
+  fastify.post<{
+    Body: {
+      collection: string
+      projectId: string
+      items: Array<Record<string, any>>
+    }
+  }>('/entities/batch', {
+    preHandler: [requireAuth, requireScope('entities:write')]
+  }, async (request, reply) => {
+    try {
+      const body = EntityBatchCreateSchema.parse(request.body)
+      const { collection, projectId, items } = body
+
+      const hasAccess = await requireProjectOwnership(request, reply, projectId)
+      if (!hasAccess) return
+
+      // Resolve the target bobbin ONCE — every item shares the collection,
+      // so per-item lookups would be redundant work.
+      const userId = request.user!.id
+      const effective = await getEffectiveBobbins(projectId, userId)
+
+      if (effective.length === 0) {
+        return reply.status(400).send({ error: 'No bobbins installed in project' })
+      }
+
+      let match = await findBobbinForCollectionAcrossScopes(effective, collection)
+
+      if (!match) {
+        const collectionIds = await getCollectionIdsForProject(projectId)
+        const scopeFilter = buildScopeCondition(projectId, collectionIds, userId)
+        match = await resolveEntityTypeCollection(effective, collection, scopeFilter)
+      }
+
+      if (!match) {
+        return reply.status(400).send({
+          error: `Collection '${collection}' not found in any installed bobbin`
+        })
+      }
+
+      // Capture the narrowed bobbin so TS keeps the non-null type inside the
+      // async transaction callback.
+      const resolved = match
+
+      const created = await db.transaction(async (tx) => {
+        const inserted: Array<typeof entities.$inferSelect> = []
+
+        for (const itemData of items) {
+          const data: Record<string, any> = { ...itemData }
+          const now = new Date().toISOString()
+          data.created_at = data.created_at ?? now
+          data.updated_at = now
+
+          if (collection === 'content' && typeof data.body === 'string') {
+            data.word_count = countWordsFromHtml(data.body)
+          }
+
+          const insertValues: Record<string, any> = {
+            id: crypto.randomUUID(),
+            bobbinId: resolved.bobbinId,
+            collectionName: collection,
+            entityData: data,
+            scope: resolved.scope,
+          }
+
+          if (resolved.scope === 'project') {
+            insertValues.projectId = projectId
+          } else if (resolved.scope === 'collection') {
+            insertValues.collectionId = resolved.scopeOwnerId
+          } else {
+            insertValues.userId = userId
+          }
+
+          const result = await tx
+            .insert(entities)
+            .values(insertValues as any)
+            .returning()
+
+          if (!result[0]) {
+            throw new Error('Insert returned no row')
+          }
+          inserted.push(result[0])
+        }
+
+        return inserted
+      })
+
+      return { entities: created.map(row => formatEntityResponse(row)) }
+
+    } catch (error) {
+      fastify.log.error(error)
+
+      if (error instanceof z.ZodError) {
+        return reply.status(400).send({
+          error: 'Validation failed',
+          issues: error.issues.map(issue => ({
+            field: issue.path.join('.'),
+            message: issue.message
+          }))
+        })
+      }
+
+      return reply.status(500).send({
+        error: 'Failed to create entities (batch rolled back)',
         details: error instanceof Error ? error.message : 'Unknown error'
       })
     }

--- a/apps/api/src/routes/uploads.ts
+++ b/apps/api/src/routes/uploads.ts
@@ -35,7 +35,27 @@ const ALLOWED_IMAGE_TYPES = new Set([
   'image/gif',
 ])
 
-const UPLOAD_CONTEXTS = new Set(['cover', 'entity', 'editor', 'avatar', 'map'])
+// Source documents accepted for the manuscript import flow. These are read
+// once by the importer (POST /import/parse) and then deleted from S3 — they
+// are not served back to browsers, so script-bearing formats are acceptable
+// here as long as the import pipeline sanitizes parser output.
+const ALLOWED_IMPORT_TYPES = new Set([
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
+  'application/epub+zip',           // .epub
+  'application/pdf',                // .pdf
+  'application/vnd.oasis.opendocument.text', // .odt
+  'application/rtf',                // .rtf (RFC 1521)
+  'text/rtf',                       // .rtf (legacy)
+  'text/markdown',                  // .md
+  'text/plain',                     // .txt
+  'text/html',                      // .html
+])
+
+const UPLOAD_CONTEXTS = new Set(['cover', 'entity', 'editor', 'avatar', 'map', 'import'])
+
+function getAllowedTypes(context: string): Set<string> {
+  return context === 'import' ? ALLOWED_IMPORT_TYPES : ALLOWED_IMAGE_TYPES
+}
 
 /** Size limits are now managed by getSizeLimits() in lib/membership.ts */
 
@@ -45,6 +65,15 @@ function extFromMime(mime: string): string {
     'image/png': 'png',
     'image/webp': 'webp',
     'image/gif': 'gif',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+    'application/epub+zip': 'epub',
+    'application/pdf': 'pdf',
+    'application/vnd.oasis.opendocument.text': 'odt',
+    'application/rtf': 'rtf',
+    'text/rtf': 'rtf',
+    'text/markdown': 'md',
+    'text/plain': 'txt',
+    'text/html': 'html',
   }
   return map[mime] || 'bin'
 }
@@ -72,6 +101,8 @@ function buildS3Key(opts: {
       return `users/${opts.userId}/avatars/${id}.${ext}`
     case 'map':
       return `projects/${opts.projectId}/entities/${opts.collection || '_'}/${opts.entityId || '_'}/${id}.${ext}`
+    case 'import':
+      return `projects/${opts.projectId}/imports/${id}.${ext}`
     default:
       return `misc/${id}.${ext}`
   }
@@ -112,9 +143,10 @@ async function uploadsPlugin(fastify: FastifyInstance) {
       })
     }
 
-    // Validate content type
-    if (!contentType || !ALLOWED_IMAGE_TYPES.has(contentType)) {
-      return reply.status(400).send({ error: `Unsupported content type. Allowed: ${[...ALLOWED_IMAGE_TYPES].join(', ')}` })
+    // Validate content type (allowed set varies by context)
+    const allowedTypes = getAllowedTypes(context)
+    if (!contentType || !allowedTypes.has(contentType)) {
+      return reply.status(400).send({ error: `Unsupported content type. Allowed: ${[...allowedTypes].join(', ')}` })
     }
 
     // Validate file size (tier-aware)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -339,6 +339,31 @@ export class EntityAPI {
     return response.json()
   }
 
+  /**
+   * Create many entities in one atomic transaction. All items go into the same
+   * collection; if any insert fails, the whole batch rolls back. Capped at 500
+   * items server-side. Use the atomic-batch endpoint for mixed create/update/delete.
+   */
+  async createBatch<T = any>(collection: string, items: Array<Partial<T>>): Promise<T[]> {
+    const response = await fetch(`${this.api.apiBaseUrl}/entities/batch`, {
+      method: 'POST',
+      headers: this.api.getAuthHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({
+        collection,
+        projectId: this.projectId,
+        items
+      })
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ error: 'Unknown error' }))
+      throw new Error(`Failed to create entities (batch): ${errorData.error || response.statusText}`)
+    }
+
+    const result = await response.json()
+    return result.entities || []
+  }
+
   async update<T = any>(collection: string, id: string, data: Partial<T>, expectedVersion?: number): Promise<T> {
     const body: Record<string, any> = {
       collection,
@@ -721,7 +746,7 @@ export class ReaderAPI {
 export interface UploadOptions {
   file: File
   projectId?: string
-  context: 'cover' | 'entity' | 'editor' | 'avatar' | 'map'
+  context: 'cover' | 'entity' | 'editor' | 'avatar' | 'map' | 'import'
   entityId?: string
   collection?: string
   onProgress?: (percent: number) => void


### PR DESCRIPTION
## Summary

Foundation work for the upcoming manuscript-import wizard. No user-visible UI yet — both pieces ship as plumbing so the wizard can build on a stable base.

**Phase 1 — `'import'` upload context**
- Widens the existing presigned-URL flow in `apps/api/src/routes/uploads.ts` to accept manuscript source documents (`.docx`, `.epub`, `.pdf`, `.odt`, `.rtf`, `.md`, `.txt`, `.html`) under a new `'import'` context.
- New S3 key scheme: `projects/{projectId}/imports/{uuid}.{ext}`.
- 25 MB base size cap (50 MB on supporter via the existing multiplier) — added as `import` in `getSizeLimits()`.
- SDK `UploadOptions.context` union widened to include `'import'`.

**Phase 2 — `POST /entities/batch`**
- Homogeneous bulk-create endpoint in `apps/api/src/routes/entities.ts`: every item lands in the same collection in the same project.
- Caps batch size at 500 items. Resolves the target bobbin **once** for the whole batch (vs. N lookups in a loop).
- Wraps inserts in `db.transaction()` — any failure rolls the whole batch back.
- Mirrors single-create's auto-stamped timestamps and `word_count` computation (for `content` collection items with an HTML `body`).
- Use the existing `/entities/batch/atomic` endpoint when you need mixed create/update/delete.
- SDK `entities.createBatch(collection, items)` added.

## Why this lands now

The eventual import flow (`POST /import/parse` → preview → `POST /import/commit`) needs both pieces:
- The presigned-URL primitive — but only image MIMEs are allowed today.
- An atomic way to land N chapters in one shot — otherwise we'd issue 500 sequential `POST /entities` calls per imported novel and partial failures would leave orphaned chapters.

Shipping these as a standalone PR keeps each phase reviewable; the wizard PR will be UI-heavy and shouldn't bury foundational route work.

## Test plan

- [x] `bun run typecheck` — clean across 47 tasks
- [x] `bun run lint` + `bun run lint:bobbins` — clean
- [x] `bun run test` — 59 unit tests pass
- [x] Full pre-commit hook (lockfile / schema drift / lint / bobbin lint / vercel compat / dockerfile workspaces / typecheck / build) — clean
- [ ] Manual: `POST /uploads/presign` with `context: 'import'` and a `.docx` MIME returns a presigned URL; same with `image/jpeg` returns 400 `Unsupported content type`
- [ ] Manual: `POST /uploads/presign` with `context: 'cover'` and a `.docx` MIME still returns 400 (cover stays image-only)
- [ ] Manual: `POST /entities/batch` with 3 `content` items creates all 3 entities under the manuscript bobbin with sequential `created_at`s and auto-computed `word_count`s
- [ ] Manual: `POST /entities/batch` where the third item violates a constraint returns 5xx and the first two are NOT persisted (transaction rollback)
- [ ] Manual: `POST /entities/batch` with `items.length === 501` returns 400 with the batch-size error