### PR TITLE
Add ODT + RTF importers (Phases 7 + 8)

### DIFF
--- a/apps/api/src/lib/import-parsers/index.ts
+++ b/apps/api/src/lib/import-parsers/index.ts
@@ -101,9 +101,15 @@ export async function parseBuffer(
       const { parseEpub } = await import('./epub')
       return parseEpub(buffer, ctx)
     }
+    case 'odt': {
+      const { parseOdt } = await import('./odt')
+      return parseOdt(buffer, ctx)
+    }
+    case 'rtf': {
+      const { parseRtf } = await import('./rtf')
+      return parseRtf(buffer, ctx)
+    }
     case 'html':
-    case 'odt':
-    case 'rtf':
     case 'pdf':
       throw new UnsupportedFormatError(format)
   }

--- a/apps/api/src/lib/import-parsers/odt.ts
+++ b/apps/api/src/lib/import-parsers/odt.ts
@@ -1,0 +1,409 @@
+/**
+ * OpenDocument Text (.odt) manuscript parser.
+ *
+ * Unzips the package, walks content.xml with fast-xml-parser (preserveOrder
+ * so interleaved text:p / text:h / soft-page-break elements stay in document
+ * order), and emits a Tiptap-safe HTML subset. Splits primarily on
+ * <text:soft-page-break/> markers (LibreOffice's automatic pagination) and
+ * falls back to top-level <h1> headings when no page breaks exist.
+ *
+ * Inline styling (bold/italic/etc.) is dropped in v1 — preserving it
+ * requires resolving text:span style-name references against styles.xml,
+ * which is significantly more work than the rest of the parser combined.
+ * The wizard's warnings banner surfaces this so users know to re-check.
+ *
+ * Embedded images in the Pictures/ folder are uploaded to S3 through the
+ * shared images helper, with <img src> rewritten before sanitization.
+ */
+
+import { randomUUID } from 'crypto'
+import JSZip from 'jszip'
+import { XMLParser } from 'fast-xml-parser'
+import * as cheerio from 'cheerio'
+import type {
+  ImportSegment,
+  ImportWarning,
+  ParserContext,
+  ParserResult,
+} from './index'
+import { sanitizeImportedHtml } from './sanitize'
+import { uploadImportImage } from './images'
+import { assertSafeZip } from './zip-safe'
+
+const PAGE_BREAK_MARKER = '☃___bbnr_odt_pb___☃'
+const FIRST_LINE_LIMIT = 140
+const TITLE_FALLBACK_LIMIT = 80
+
+const xml = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  preserveOrder: true,
+  parseAttributeValue: false,
+  trimValues: false,
+})
+
+interface ImageRef {
+  zipPath: string
+  alt: string
+}
+
+type XmlNode = Record<string, unknown>
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, '&quot;')
+}
+
+function tagOf(node: XmlNode): string | null {
+  for (const key of Object.keys(node)) {
+    if (key !== ':@') return key
+  }
+  return null
+}
+
+function attrsOf(node: XmlNode): Record<string, string> {
+  const raw = node[':@']
+  return (raw && typeof raw === 'object' ? raw : {}) as Record<string, string>
+}
+
+function asNodeArray(value: unknown): XmlNode[] {
+  if (!Array.isArray(value)) return []
+  return value as XmlNode[]
+}
+
+/** Walk parsed XML to find office:document-content > office:body > office:text. */
+function findOfficeText(parsed: XmlNode[]): XmlNode[] {
+  for (const top of parsed) {
+    const docContent = top['office:document-content']
+    if (!Array.isArray(docContent)) continue
+    for (const child of docContent as XmlNode[]) {
+      const body = child['office:body']
+      if (!Array.isArray(body)) continue
+      for (const inner of body as XmlNode[]) {
+        const text = inner['office:text']
+        if (Array.isArray(text)) return text as XmlNode[]
+      }
+    }
+  }
+  return []
+}
+
+class EmitContext {
+  images: Map<string, ImageRef> = new Map()
+
+  /** Register an image href and return a placeholder string the emitter
+   *  embeds in the rendered HTML. The caller does an async pass after
+   *  emission to swap placeholders for uploaded URLs. */
+  reserveImage(href: string, alt: string): string {
+    const placeholder = `__bbnr_odt_img_${this.images.size}__`
+    this.images.set(placeholder, { zipPath: href, alt })
+    return placeholder
+  }
+}
+
+function emitNode(node: XmlNode, ctx: EmitContext): string {
+  const tag = tagOf(node)
+  if (!tag) return ''
+  const children = asNodeArray(node[tag])
+
+  if (tag === '#text') {
+    // `node[tag]` for #text is the raw string (preserveOrder shape).
+    const raw = (node['#text'] ?? '') as string
+    return escapeHtml(String(raw))
+  }
+
+  const attrs = attrsOf(node)
+
+  switch (tag) {
+    case 'text:p':
+      return `<p>${emitChildren(children, ctx)}</p>`
+
+    case 'text:h': {
+      const levelRaw = attrs['@_text:outline-level'] ?? '1'
+      const level = Math.min(Math.max(parseInt(levelRaw, 10) || 1, 1), 6)
+      return `<h${level}>${emitChildren(children, ctx)}</h${level}>`
+    }
+
+    case 'text:soft-page-break':
+      return PAGE_BREAK_MARKER
+
+    case 'text:line-break':
+      return '<br/>'
+
+    case 'text:tab':
+      return '    '
+
+    case 'text:s': {
+      // text:s c="N" → N spaces
+      const count = parseInt(attrs['@_text:c'] ?? '1', 10) || 1
+      return ' '.repeat(count)
+    }
+
+    case 'text:list':
+      return `<ul>${emitChildren(children, ctx)}</ul>`
+
+    case 'text:list-item':
+      return `<li>${emitChildren(children, ctx)}</li>`
+
+    case 'text:a': {
+      const href = attrs['@_xlink:href'] ?? ''
+      return `<a href="${escapeAttr(href)}">${emitChildren(children, ctx)}</a>`
+    }
+
+    case 'text:span':
+      // Drop inline styling for v1; emit children inline.
+      return emitChildren(children, ctx)
+
+    case 'draw:frame':
+      // Unwrap; the <draw:image> inside emits the actual <img>.
+      return emitChildren(children, ctx)
+
+    case 'draw:image': {
+      const href = attrs['@_xlink:href'] ?? ''
+      if (!href) return ''
+      const placeholder = ctx.reserveImage(href, '')
+      return `<img src="${escapeAttr(placeholder)}" alt=""/>`
+    }
+
+    case 'table:table':
+      // Drop tables for v1 — Tiptap's starter kit doesn't render them
+      // without the @tiptap/extension-table plugin, which manuscript
+      // doesn't load. Keep the cell text so content isn't lost.
+      return `<p>${emitChildren(children, ctx)}</p>`
+
+    case 'table:table-row':
+    case 'table:table-cell':
+      return emitChildren(children, ctx) + ' '
+
+    default:
+      // Unknown / structural tag: emit children, drop the wrapper.
+      return emitChildren(children, ctx)
+  }
+}
+
+function emitChildren(children: XmlNode[], ctx: EmitContext): string {
+  return children.map(c => emitNode(c, ctx)).join('')
+}
+
+async function rewriteImages(
+  html: string,
+  ctx: EmitContext,
+  zip: JSZip,
+  parseCtx: ParserContext,
+  imageErrors: string[],
+): Promise<string> {
+  let out = html
+  for (const [placeholder, ref] of ctx.images.entries()) {
+    const file = zip.file(ref.zipPath)
+    if (!file) {
+      imageErrors.push(`Image not found in archive: ${ref.zipPath}`)
+      out = out.split(placeholder).join('')
+      continue
+    }
+    let buffer: Buffer
+    try {
+      buffer = await file.async('nodebuffer')
+    } catch (err) {
+      imageErrors.push(`Could not read image '${ref.zipPath}': ${err instanceof Error ? err.message : 'unknown'}`)
+      out = out.split(placeholder).join('')
+      continue
+    }
+    // Sniff the MIME from the file extension since ODT doesn't carry it.
+    const mime = mimeFromName(ref.zipPath)
+    const { url, warning } = await uploadImportImage(buffer, mime, parseCtx)
+    if (warning) imageErrors.push(warning)
+    if (!url) {
+      out = out.split(placeholder).join('')
+      continue
+    }
+    out = out.split(placeholder).join(url)
+  }
+  return out
+}
+
+function mimeFromName(name: string): string {
+  const ext = name.split('.').pop()?.toLowerCase() ?? ''
+  switch (ext) {
+    case 'png': return 'image/png'
+    case 'jpg':
+    case 'jpeg': return 'image/jpeg'
+    case 'gif': return 'image/gif'
+    case 'webp': return 'image/webp'
+    default: return 'application/octet-stream'
+  }
+}
+
+function countWordsFromText(text: string): number {
+  return text.split(/\s+/).filter(w => w.length > 0).length
+}
+
+function firstSnippet(text: string): string {
+  const t = text.replace(/\s+/g, ' ').trim()
+  return t.length > FIRST_LINE_LIMIT ? t.slice(0, FIRST_LINE_LIMIT) + '…' : t
+}
+
+function extractTitle(html: string, fallback: string): string {
+  const $ = cheerio.load(`<div id="root">${html}</div>`, null, false)
+  const root = $('#root')
+  for (const tag of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']) {
+    const el = root.find(tag).first()
+    if (el.length > 0) {
+      const text = el.text().trim()
+      if (text) {
+        return text.length > TITLE_FALLBACK_LIMIT
+          ? text.slice(0, TITLE_FALLBACK_LIMIT) + '…'
+          : text
+      }
+    }
+  }
+  const firstP = root.find('p').first()
+  const text = firstP.text().trim()
+  if (text) {
+    return text.length > TITLE_FALLBACK_LIMIT
+      ? text.slice(0, TITLE_FALLBACK_LIMIT) + '…'
+      : text
+  }
+  return fallback
+}
+
+function splitByMarker(html: string): string[] {
+  const parts = html.split(PAGE_BREAK_MARKER)
+  return parts.map(p => p.trim()).filter(p => p.length > 0)
+}
+
+function splitByH1(html: string): string[] {
+  const $ = cheerio.load(`<div id="root">${html}</div>`, null, false)
+  const root = $('#root')
+  const segs: string[] = []
+  let buf: string[] = []
+  let sawH1 = false
+  root.children().each((_idx, elem) => {
+    const tagName = $(elem).prop('tagName')?.toLowerCase()
+    if (tagName === 'h1') {
+      if (buf.length > 0) segs.push(buf.join(''))
+      buf = [$.html(elem)]
+      sawH1 = true
+    } else {
+      buf.push($.html(elem))
+    }
+  })
+  if (buf.length > 0) segs.push(buf.join(''))
+  return sawH1 ? segs : [html]
+}
+
+export async function parseOdt(
+  buffer: Buffer,
+  ctx: ParserContext,
+): Promise<ParserResult> {
+  const warnings: ImportWarning[] = []
+  const imageErrors: string[] = []
+
+  let zip: JSZip
+  try {
+    zip = await JSZip.loadAsync(buffer)
+  } catch (err) {
+    throw new Error(`Not a valid ODT archive: ${err instanceof Error ? err.message : 'unknown'}`)
+  }
+
+  assertSafeZip(zip)
+
+  const contentEntry = zip.file('content.xml')
+  if (!contentEntry) throw new Error('ODT is missing content.xml')
+  const contentXmlText = await contentEntry.async('string')
+  const parsed = xml.parse(contentXmlText) as XmlNode[]
+
+  const officeText = findOfficeText(parsed)
+  if (officeText.length === 0) {
+    warnings.push({
+      code: 'EMPTY_DOCUMENT',
+      message: 'ODT document body is empty.',
+    })
+    return {
+      segments: [{
+        tempId: randomUUID(),
+        suggestedTitle: 'Imported manuscript',
+        html: '',
+        wordCount: 0,
+        firstLine: '',
+      }],
+      warnings,
+      sourceFormat: 'odt',
+    }
+  }
+
+  const emitCtx = new EmitContext()
+  const rawHtml = emitChildren(officeText, emitCtx)
+  const htmlWithImages = await rewriteImages(rawHtml, emitCtx, zip, ctx, imageErrors)
+
+  if (imageErrors.length > 0) {
+    warnings.push({
+      code: 'IMAGE_FAILED',
+      message: `${imageErrors.length} embedded image${imageErrors.length === 1 ? '' : 's'} could not be imported.`,
+      detail: imageErrors.slice(0, 3).join(' · '),
+    })
+  }
+
+  warnings.push({
+    code: 'FORMATTING_LOST',
+    message: 'Inline emphasis (bold, italic) is not preserved from ODT in this build.',
+  })
+
+  // First split by soft page breaks. If exactly one chunk, try H1.
+  let rawSegments = splitByMarker(htmlWithImages)
+  if (rawSegments.length <= 1) {
+    rawSegments = splitByH1(rawSegments[0] ?? htmlWithImages)
+    if (rawSegments.length === 1) {
+      warnings.push({
+        code: 'STRUCTURE_GUESSED',
+        message:
+          'No page breaks or top-level headings found — imported as a single chapter. Split it manually in the preview.',
+      })
+    }
+  }
+
+  const segments: ImportSegment[] = []
+  for (let i = 0; i < rawSegments.length; i++) {
+    const segHtml = rawSegments[i]!
+    const sanitized = sanitizeImportedHtml(segHtml)
+    const $ = cheerio.load(`<div id="root">${sanitized}</div>`, null, false)
+    const root = $('#root')
+    const fullText = root.text()
+    if (fullText.replace(/\s+/g, '').length === 0) continue
+    const firstPara = root.find('p').filter((_idx, el) => $(el).text().trim().length > 0).first()
+    const firstLineSource = firstPara.length > 0 ? firstPara.text() : fullText
+    segments.push({
+      tempId: randomUUID(),
+      suggestedTitle: extractTitle(sanitized, `Chapter ${i + 1}`),
+      html: sanitized,
+      wordCount: countWordsFromText(fullText),
+      firstLine: firstSnippet(firstLineSource),
+    })
+  }
+
+  if (segments.length === 0) {
+    warnings.push({
+      code: 'EMPTY_DOCUMENT',
+      message: 'No readable text found in the ODT.',
+    })
+    return {
+      segments: [{
+        tempId: randomUUID(),
+        suggestedTitle: 'Imported manuscript',
+        html: '',
+        wordCount: 0,
+        firstLine: '',
+      }],
+      warnings,
+      sourceFormat: 'odt',
+    }
+  }
+
+  return { segments, warnings, sourceFormat: 'odt' }
+}

--- a/apps/api/src/lib/import-parsers/rtf.ts
+++ b/apps/api/src/lib/import-parsers/rtf.ts
@@ -1,0 +1,405 @@
+/**
+ * Rich Text Format (.rtf) manuscript parser.
+ *
+ * A minimal hand-rolled extractor: walks the RTF byte stream, skips known
+ * non-content destinations (font/color/style tables, info, generator,
+ * pictures), and emits the remaining text grouped into paragraphs on
+ * \par / \page / \sect boundaries. Splits the resulting HTML on top-level
+ * <h1>-like markers (RTF doesn't have a reliable explicit page break,
+ * see the FORMATTING_LOST warning we always surface).
+ *
+ * Inline emphasis (bold, italic, etc.) is dropped on purpose — preserving
+ * it from RTF reliably across producers (Word, LibreOffice, Mac TextEdit,
+ * Apache OpenOffice) is brittle and the planner's notes flag the existing
+ * RTF library landscape as "genuinely weak". We trade fidelity for
+ * reliability and tell the user upfront.
+ */
+
+import { randomUUID } from 'crypto'
+import * as cheerio from 'cheerio'
+import type {
+  ImportSegment,
+  ImportWarning,
+  ParserContext,
+  ParserResult,
+} from './index'
+import { sanitizeImportedHtml } from './sanitize'
+
+const FIRST_LINE_LIMIT = 140
+const TITLE_FALLBACK_LIMIT = 80
+const CHAPTER_HINT = /^(chapter|prologue|epilogue|part|book)\b/i
+
+const SKIP_DESTINATIONS = new Set([
+  'fonttbl', 'filetbl', 'colortbl', 'stylesheet', 'info', 'pict',
+  'object', 'rsidtbl', 'generator', 'listtable', 'listoverridetable',
+  'xmlnstbl', 'datastore', 'header', 'footer', 'header1', 'footer1',
+  'headerf', 'footerf', 'headerl', 'footerl', 'headerr', 'footerr',
+  'comment', 'atnauthor', 'atndate', 'atnid', 'atnref', 'atntime',
+  'bkmkstart', 'bkmkend', 'footnote', 'annotation', 'falt',
+  'fldinst', 'private', 'themedata', 'colorschememapping',
+  'latentstyles', 'datafield',
+])
+
+interface ParserState {
+  /** Text buffer for the current paragraph */
+  buf: string[]
+  /** Completed paragraphs, plain text */
+  paragraphs: string[]
+  /** Stack of "skip text" flags, one per group depth */
+  skipStack: boolean[]
+  /** Whether the next control word is the destination marker after \\* */
+  ignoreNextUnknown: boolean
+}
+
+function flushParagraph(state: ParserState) {
+  const text = state.buf.join('').trim()
+  if (text.length > 0) {
+    state.paragraphs.push(text)
+  }
+  state.buf = []
+}
+
+function appendChar(state: ParserState, ch: string) {
+  if (state.skipStack[state.skipStack.length - 1]) return
+  state.buf.push(ch)
+}
+
+function appendText(state: ParserState, text: string) {
+  if (state.skipStack[state.skipStack.length - 1]) return
+  state.buf.push(text)
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/** Decode the byte from `\\'XX` as Windows-1252 (the most common RTF
+ *  character set; full Unicode passes through `\\uN` separately). */
+function decodeHexByte(hex: string): string {
+  const byte = parseInt(hex, 16)
+  if (isNaN(byte)) return ''
+  // Windows-1252 special range 0x80-0x9F maps to specific code points.
+  const cp1252Specials: Record<number, number> = {
+    0x80: 0x20AC, 0x82: 0x201A, 0x83: 0x0192, 0x84: 0x201E,
+    0x85: 0x2026, 0x86: 0x2020, 0x87: 0x2021, 0x88: 0x02C6,
+    0x89: 0x2030, 0x8A: 0x0160, 0x8B: 0x2039, 0x8C: 0x0152,
+    0x8E: 0x017D, 0x91: 0x2018, 0x92: 0x2019, 0x93: 0x201C,
+    0x94: 0x201D, 0x95: 0x2022, 0x96: 0x2013, 0x97: 0x2014,
+    0x98: 0x02DC, 0x99: 0x2122, 0x9A: 0x0161, 0x9B: 0x203A,
+    0x9C: 0x0153, 0x9E: 0x017E, 0x9F: 0x0178,
+  }
+  if (cp1252Specials[byte] !== undefined) {
+    return String.fromCodePoint(cp1252Specials[byte]!)
+  }
+  return String.fromCharCode(byte)
+}
+
+function extractText(rtf: string): string[] {
+  const state: ParserState = {
+    buf: [],
+    paragraphs: [],
+    skipStack: [false],
+    ignoreNextUnknown: false,
+  }
+
+  let i = 0
+  const len = rtf.length
+
+  while (i < len) {
+    const ch = rtf[i]!
+
+    if (ch === '{') {
+      // New group — inherit parent's skip state
+      const top = state.skipStack[state.skipStack.length - 1]!
+      state.skipStack.push(top)
+      i++
+      continue
+    }
+
+    if (ch === '}') {
+      state.skipStack.pop()
+      // Restore to non-empty stack
+      if (state.skipStack.length === 0) state.skipStack.push(false)
+      i++
+      continue
+    }
+
+    if (ch === '\\') {
+      const next = rtf[i + 1]
+      if (next === undefined) { i++; continue }
+
+      // Escaped specials
+      if (next === '\\' || next === '{' || next === '}') {
+        appendChar(state, next)
+        i += 2
+        continue
+      }
+
+      // Hex-encoded byte: \'XX
+      if (next === "'") {
+        const hex = rtf.substr(i + 2, 2)
+        appendText(state, decodeHexByte(hex))
+        i += 4
+        continue
+      }
+
+      // Unicode escape: \uN[?] — N is signed 16-bit decimal
+      if (next === 'u') {
+        // Read signed decimal after 'u'
+        let j = i + 2
+        let sign = 1
+        if (rtf[j] === '-') { sign = -1; j++ }
+        let digits = ''
+        while (j < len && /\d/.test(rtf[j]!)) {
+          digits += rtf[j]
+          j++
+        }
+        if (digits.length > 0) {
+          let code = parseInt(digits, 10) * sign
+          if (code < 0) code = code + 0x10000
+          appendText(state, String.fromCodePoint(code))
+          // Skip the alternate replacement char (typically '?')
+          if (rtf[j] === ' ') j++
+          if (rtf[j] === '?') j++
+          i = j
+          continue
+        }
+      }
+
+      // Special "ignore-if-unknown destination" marker: \*
+      if (next === '*') {
+        state.ignoreNextUnknown = true
+        i += 2
+        continue
+      }
+
+      // Control word: \word[N][ ]
+      if (/[a-zA-Z]/.test(next)) {
+        let j = i + 1
+        let word = ''
+        while (j < len && /[a-zA-Z]/.test(rtf[j]!)) {
+          word += rtf[j]
+          j++
+        }
+        // Optional numeric parameter
+        let param = ''
+        if (rtf[j] === '-') { param = '-'; j++ }
+        while (j < len && /\d/.test(rtf[j]!)) {
+          param += rtf[j]
+          j++
+        }
+        // Optional single trailing space (eaten as part of the control word)
+        if (rtf[j] === ' ') j++
+
+        handleControlWord(state, word, param)
+        i = j
+        continue
+      }
+
+      // Other control symbol (single character, no param) — skip
+      i += 2
+      continue
+    }
+
+    if (ch === '\r' || ch === '\n') {
+      // Whitespace between control words / formatting — ignore (RTF doesn't
+      // use \n for paragraph breaks; \par does).
+      i++
+      continue
+    }
+
+    // Plain text byte
+    appendChar(state, ch)
+    i++
+  }
+
+  flushParagraph(state)
+  return state.paragraphs
+}
+
+function handleControlWord(state: ParserState, word: string, _param: string) {
+  // Destination control words — push true onto the skip stack for known
+  // non-content destinations. If we see \* and don't recognize the next
+  // control word, also skip its group.
+  const wasIgnoreNext = state.ignoreNextUnknown
+  state.ignoreNextUnknown = false
+
+  if (SKIP_DESTINATIONS.has(word)) {
+    if (state.skipStack.length > 0) {
+      state.skipStack[state.skipStack.length - 1] = true
+    }
+    return
+  }
+
+  if (wasIgnoreNext) {
+    // Unknown extension destination — skip the group.
+    if (state.skipStack.length > 0) {
+      state.skipStack[state.skipStack.length - 1] = true
+    }
+    return
+  }
+
+  // Paragraph breaks
+  if (word === 'par' || word === 'sect' || word === 'page' || word === 'pard') {
+    if (word === 'par' || word === 'sect' || word === 'page') {
+      flushParagraph(state)
+    }
+    return
+  }
+
+  // Tab + line break
+  if (word === 'tab') { appendChar(state, '\t'); return }
+  if (word === 'line') { appendChar(state, '\n'); return }
+
+  // Common special characters
+  if (word === 'emdash') { appendText(state, '—'); return }
+  if (word === 'endash') { appendText(state, '–'); return }
+  if (word === 'lquote') { appendText(state, '‘'); return }
+  if (word === 'rquote') { appendText(state, '’'); return }
+  if (word === 'ldblquote') { appendText(state, '“'); return }
+  if (word === 'rdblquote') { appendText(state, '”'); return }
+  if (word === 'bullet') { appendText(state, '•'); return }
+  if (word === 'nbsp') { appendText(state, ' '); return }
+  if (word === 'tilde') { appendText(state, '~'); return }
+
+  // Everything else (formatting commands like \b, \i, fonts, colors, etc.)
+  // is ignored. We're text-only for v1.
+}
+
+function paragraphsToHtml(paragraphs: string[]): string {
+  return paragraphs
+    .map(p => {
+      // Detect chapter-keyword paragraphs and promote to <h1> so the
+      // splitter can use them. Otherwise emit <p>.
+      if (CHAPTER_HINT.test(p) && p.length < 120) {
+        return `<h1>${escapeHtml(p)}</h1>`
+      }
+      return `<p>${escapeHtml(p)}</p>`
+    })
+    .join('\n')
+}
+
+function countWordsFromText(text: string): number {
+  return text.split(/\s+/).filter(w => w.length > 0).length
+}
+
+function firstSnippet(text: string): string {
+  const t = text.replace(/\s+/g, ' ').trim()
+  return t.length > FIRST_LINE_LIMIT ? t.slice(0, FIRST_LINE_LIMIT) + '…' : t
+}
+
+function extractTitle(html: string, fallback: string): string {
+  const $ = cheerio.load(`<div id="root">${html}</div>`, null, false)
+  const root = $('#root')
+  for (const tag of ['h1', 'h2', 'h3']) {
+    const el = root.find(tag).first()
+    if (el.length > 0) {
+      const text = el.text().trim()
+      if (text) {
+        return text.length > TITLE_FALLBACK_LIMIT
+          ? text.slice(0, TITLE_FALLBACK_LIMIT) + '…'
+          : text
+      }
+    }
+  }
+  const firstP = root.find('p').first()
+  const text = firstP.text().trim()
+  if (text) {
+    return text.length > TITLE_FALLBACK_LIMIT
+      ? text.slice(0, TITLE_FALLBACK_LIMIT) + '…'
+      : text
+  }
+  return fallback
+}
+
+function splitByH1(html: string): string[] {
+  const $ = cheerio.load(`<div id="root">${html}</div>`, null, false)
+  const root = $('#root')
+  const segs: string[] = []
+  let buf: string[] = []
+  let sawH1 = false
+  root.children().each((_idx, elem) => {
+    const tagName = $(elem).prop('tagName')?.toLowerCase()
+    if (tagName === 'h1') {
+      if (buf.length > 0) segs.push(buf.join(''))
+      buf = [$.html(elem)]
+      sawH1 = true
+    } else {
+      buf.push($.html(elem))
+    }
+  })
+  if (buf.length > 0) segs.push(buf.join(''))
+  return sawH1 ? segs : [html]
+}
+
+export async function parseRtf(
+  buffer: Buffer,
+  _ctx: ParserContext,
+): Promise<ParserResult> {
+  const warnings: ImportWarning[] = []
+  const text = buffer.toString('utf8')
+
+  if (!text.startsWith('{\\rtf')) {
+    throw new Error('Not a valid RTF document (missing {\\rtf header)')
+  }
+
+  const paragraphs = extractText(text)
+  if (paragraphs.length === 0) {
+    warnings.push({
+      code: 'EMPTY_DOCUMENT',
+      message: 'No readable text found in the RTF document.',
+    })
+    return {
+      segments: [{
+        tempId: randomUUID(),
+        suggestedTitle: 'Imported manuscript',
+        html: '',
+        wordCount: 0,
+        firstLine: '',
+      }],
+      warnings,
+      sourceFormat: 'rtf',
+    }
+  }
+
+  warnings.push({
+    code: 'FORMATTING_LOST',
+    message: 'RTF imports preserve text and paragraph structure only; inline emphasis, images, fonts, and tables are dropped.',
+  })
+
+  const html = paragraphsToHtml(paragraphs)
+
+  // Split on the synthetic <h1> chapter markers we inserted during emit.
+  const rawSegments = splitByH1(html)
+  if (rawSegments.length === 1) {
+    warnings.push({
+      code: 'STRUCTURE_GUESSED',
+      message:
+        'No chapter markers found — imported as a single chapter. Split it manually in the preview.',
+    })
+  }
+
+  const segments: ImportSegment[] = []
+  for (let i = 0; i < rawSegments.length; i++) {
+    const segHtml = rawSegments[i]!
+    const sanitized = sanitizeImportedHtml(segHtml)
+    const $ = cheerio.load(`<div id="root">${sanitized}</div>`, null, false)
+    const root = $('#root')
+    const fullText = root.text()
+    if (fullText.replace(/\s+/g, '').length === 0) continue
+    const firstPara = root.find('p').filter((_idx, el) => $(el).text().trim().length > 0).first()
+    const firstLineSource = firstPara.length > 0 ? firstPara.text() : fullText
+    segments.push({
+      tempId: randomUUID(),
+      suggestedTitle: extractTitle(sanitized, `Chapter ${i + 1}`),
+      html: sanitized,
+      wordCount: countWordsFromText(fullText),
+      firstLine: firstSnippet(firstLineSource),
+    })
+  }
+
+  return { segments, warnings, sourceFormat: 'rtf' }
+}

--- a/apps/shell/src/app/projects/[projectId]/components/dashboard/ImportManuscript.tsx
+++ b/apps/shell/src/app/projects/[projectId]/components/dashboard/ImportManuscript.tsx
@@ -8,7 +8,7 @@ interface ImportManuscriptProps {
   onImportComplete?: () => void
 }
 
-const SUPPORTED_FORMATS_HINT = '.txt, .md, .docx, .epub — .pdf, .odt, .rtf, .html coming soon'
+const SUPPORTED_FORMATS_HINT = '.txt, .md, .docx, .epub, .odt, .rtf — .pdf and .html coming soon'
 
 export function ImportManuscript({ projectId, onImportComplete }: ImportManuscriptProps) {
   const [isOpen, setIsOpen] = useState(false)

--- a/apps/shell/src/app/projects/[projectId]/components/dashboard/import/ImportWizard.tsx
+++ b/apps/shell/src/app/projects/[projectId]/components/dashboard/import/ImportWizard.tsx
@@ -440,8 +440,10 @@ function PickStep({ onPickFile }: { onPickFile: (file: File) => void }) {
       <p className="text-sm text-gray-500 dark:text-gray-400 mb-5 max-w-md mx-auto">
         Currently supported: <code className="font-mono text-xs">.txt</code>,{' '}
         <code className="font-mono text-xs">.md</code>,{' '}
-        <code className="font-mono text-xs">.docx</code>, and{' '}
-        <code className="font-mono text-xs">.epub</code>. Other formats land in later phases.
+        <code className="font-mono text-xs">.docx</code>,{' '}
+        <code className="font-mono text-xs">.epub</code>,{' '}
+        <code className="font-mono text-xs">.odt</code>, and{' '}
+        <code className="font-mono text-xs">.rtf</code>. PDF and HTML land later.
       </p>
 
       <label className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 text-white rounded-lg font-medium text-sm transition-colors cursor-pointer">


### PR DESCRIPTION
## Summary

Adds two more parsers to the manuscript-import wizard: ODT and RTF.

**ODT (`apps/api/src/lib/import-parsers/odt.ts`)**
- jszip + fast-xml-parser in `preserveOrder` mode; walks `office:text` and emits a Tiptap-safe HTML subset
- Splits primarily on `<text:soft-page-break/>` (LibreOffice's automatic pagination); falls back to top-level `<h1>` (from `text:h` with outline-level=1) when no page breaks exist
- Embedded `Pictures/` images uploaded via the shared `images.ts` helper, `<img src>` rewritten before sanitization
- Inline emphasis is **dropped in v1** — resolving `text:span` style-name chains against `styles.xml` is significantly more work than the rest of the parser combined. The wizard surfaces a `FORMATTING_LOST` warning so users know to re-check.

**RTF (`apps/api/src/lib/import-parsers/rtf.ts`)**
- Minimal hand-rolled extractor instead of a third-party library — the planner's notes called the existing RTF library landscape "genuinely weak"
- Walks the RTF byte stream, skips known non-content destinations (`fonttbl`, `colortbl`, `stylesheet`, `info`, `pict`, `generator`, `listtable`, headers/footers, etc.) and groups marked `\*` + unknown control word
- Handles `\par` / `\sect` / `\page` for paragraph breaks, `\uN` and `\'XX` for Unicode / Windows-1252 character escapes, and the common special-char control words (`\emdash`, `\lquote`, `\rdblquote`, `\bullet`, `\nbsp`, ...)
- Promotes paragraph lines matching the chapter-keyword regex to `<h1>` so the existing H1 splitter can use them
- Always surfaces a `FORMATTING_LOST` warning since inline emphasis, fonts, images, and tables are dropped

## Test plan

- [x] `bun run typecheck` — clean across 48 tasks
- [x] `bun run lint` / `bun run lint:bobbins` — clean
- [x] `bun run test` — 59 unit tests pass
- [x] Full pre-commit pipeline (lockfile / schema drift / lint / bobbin lint / vercel compat / Dockerfile workspaces / typecheck / build) — clean
- [x] Curl end-to-end against the live dev API for both formats:
  - 3-chapter ODT with two soft page breaks and one embedded PNG → 3 segments, image uploaded to S3 and `<img src>` rewritten to a `projects/{id}/editor/import-{batch}/` URL
  - 3-chapter RTF with `\fonttbl`, `\colortbl`, `\page`, `\emdash`, `\lquote`/`\rquote`, and `{\b ...}` → 3 segments, formatting stripped, special chars decoded correctly

## Notes

- **Merge:** regular merge or rebase merge is fine — this is two parser files plus a tiny dispatcher + hint-text touch-up.
- Wizard hint and `<ImportManuscript />` card now list `.odt` and `.rtf` as supported. PDF and HTML still flagged as coming later.
