### PR TITLE
docx: preserve empty paragraphs, paragraph alignment + combine chapter+subtitle titles

### DIFF
--- a/apps/api/src/lib/import-parsers/docx.ts
+++ b/apps/api/src/lib/import-parsers/docx.ts
@@ -45,6 +45,12 @@ import { sanitizeImportedHtml } from './sanitize'
 import { uploadImportImage } from './images'
 
 const PAGE_BREAK_MARKER = '☃___bbnr_pb_marker___☃'
+// Alignment markers carry the value inline (`center`, `right`, `justify`).
+// transformDocument prepends one of these as a text run into each non-left
+// paragraph; a cheerio post-pass strips it and writes a `text-align` inline
+// style on the rendered <p> / <h*>. Left-aligned paragraphs are untouched
+// because that's the editor default.
+const ALIGN_MARKER_RE = /☃___bbnr_align___([a-z]+)___☃/
 const FIRST_LINE_LIMIT = 140
 const TITLE_FALLBACK_LIMIT = 80
 const CHAPTER_PARAGRAPH_RE = /^(chapter|prologue|epilogue|part|book)\b/i
@@ -268,7 +274,10 @@ function extractTitle(html: string, fallback: string): string {
     }
   }
 
-  const firstP = root.find('p').first()
+  // Now that empty paragraphs are preserved as vertical spacing, the first
+  // <p> in a segment is often blank. Skip those and grab the first <p>
+  // whose text content is non-empty.
+  const firstP = root.find('p').filter((_idx, el) => $(el).text().trim().length > 0).first()
   if (firstP.length > 0) {
     const text = firstP.text().trim()
     if (text) return text.length > TITLE_FALLBACK_LIMIT
@@ -372,6 +381,29 @@ function stripEmpty(htmls: string[]): string[] {
   return htmls.filter(h => h.replace(/<[^>]*>/g, '').replace(/\s+/g, '').length > 0)
 }
 
+/** Strip alignment markers injected via transformDocument and translate them
+ *  into a `text-align` inline style on the enclosing block element. */
+function applyAlignmentMarkers(html: string): string {
+  if (!html.includes('___bbnr_align___')) return html
+  const $ = cheerio.load(`<div id="root">${html}</div>`, null, false)
+  $('p, h1, h2, h3, h4, h5, h6').each((_idx, elem) => {
+    const $el = $(elem)
+    const inner = $el.html() ?? ''
+    const match = inner.match(ALIGN_MARKER_RE)
+    if (!match) return
+    const alignment = match[1]!
+    const cleaned = inner.replace(ALIGN_MARKER_RE, '').replace(/^\s+/, '')
+    $el.html(cleaned)
+    const existing = ($el.attr('style') ?? '')
+      .split(';')
+      .map(s => s.trim())
+      .filter(s => s.length > 0 && !s.toLowerCase().startsWith('text-align'))
+    existing.push(`text-align: ${alignment}`)
+    $el.attr('style', existing.join('; '))
+  })
+  return $('#root').html() ?? html
+}
+
 export async function parseDocx(
   buffer: Buffer,
   ctx: ParserContext,
@@ -385,15 +417,38 @@ export async function parseDocx(
   // marker into the rendered HTML after mammoth runs.
   const breakTexts = await findPageBreakParagraphTexts(buffer)
 
-  // Mammoth's TS types don't expose `images.imgElement`'s shape cleanly.
+  // Mammoth's TS types don't expose `images.imgElement` or `transforms`
+  // cleanly. The cast surfaces both for the alignment + image-rewrite work.
   interface MammothImage {
     contentType: string
     altText?: string
     read: (encoding: 'base64') => Promise<string>
   }
+  interface MammothParaForAlign {
+    alignment?: string
+    children?: Array<{ type: string; children?: Array<{ type: string; value?: string }> }>
+  }
   const mammothAny = mammoth as unknown as {
     images: { imgElement: (fn: (image: MammothImage) => Promise<{ src: string; alt?: string }>) => unknown }
+    transforms: { paragraph: (fn: (p: MammothParaForAlign) => MammothParaForAlign) => unknown }
   }
+
+  // transformDocument: prepend an alignment-marker text run to every non-left
+  // paragraph. The cheerio post-pass later converts these to inline
+  // text-align styles. Left alignment is the editor default — no marker.
+  const transformDocument = mammothAny.transforms.paragraph((para) => {
+    const a = para.alignment
+    if (a && a !== 'left' && (a === 'center' || a === 'right' || a === 'justify')) {
+      return {
+        ...para,
+        children: [
+          { type: 'run', children: [{ type: 'text', value: `☃___bbnr_align___${a}___☃` }] },
+          ...(para.children ?? []),
+        ],
+      }
+    }
+    return para
+  })
 
   const convertImage = mammothAny.images.imgElement(async (image: MammothImage) => {
     try {
@@ -415,12 +470,23 @@ export async function parseDocx(
   try {
     const result = await mammoth.convertToHtml(
       { buffer },
-      { convertImage: convertImage as never },
+      {
+        // Keep empty paragraphs so the vertical whitespace authors place
+        // around system-text blocks, between the chapter title and the
+        // first body paragraph, etc. survives into the editor.
+        ignoreEmptyParagraphs: false,
+        transformDocument: transformDocument as never,
+        convertImage: convertImage as never,
+      },
     )
     html = result.value
   } catch (err) {
     throw new Error(`Word document could not be read: ${err instanceof Error ? err.message : 'unknown error'}`)
   }
+
+  // Translate alignment markers (injected via transformDocument) into
+  // text-align inline styles on the enclosing <p> / <h*>.
+  html = applyAlignmentMarkers(html)
 
   // Post-pass: inject the page-break marker before each paragraph whose
   // OOXML counterpart had a break. Matches by text content so paragraph
@@ -507,9 +573,15 @@ export async function parseDocx(
     const root = $('#root')
     // Word count: full text content.
     const plainAll = root.text()
-    // First line: first non-heading paragraph, so the snippet isn't a
-    // concatenation of "Chapter 1: TitleFirst paragraph text..."
-    const firstP = root.find('p').filter((_idx, el) => $(el).text().trim().length > 0).first()
+    // First-line snippet: skip empty paragraphs (vertical spacing) and the
+    // chapter-title paragraph itself so the preview reads as body prose,
+    // not "Chapter One" / "Chapter One" duplicated.
+    const firstP = root.find('p').filter((_idx, el) => {
+      const text = $(el).text().trim()
+      if (text.length === 0) return false
+      if (text.length <= CHAPTER_PARAGRAPH_MAX_LEN && CHAPTER_PARAGRAPH_RE.test(text)) return false
+      return true
+    }).first()
     const firstLineSource = firstP.length > 0 ? firstP.text() : plainAll
     return {
       tempId: randomUUID(),

--- a/apps/api/src/lib/import-parsers/docx.ts
+++ b/apps/api/src/lib/import-parsers/docx.ts
@@ -56,6 +56,9 @@ const TITLE_FALLBACK_LIMIT = 80
 const CHAPTER_PARAGRAPH_RE = /^(chapter|prologue|epilogue|part|book)\b/i
 const CHAPTER_PARAGRAPH_MAX_LEN = 80
 const MATCH_PREFIX_LEN = 80
+const SUBTITLE_MAX_LEN = 120
+const TITLE_SEPARATOR = ' — '
+const INLINE_WRAPPER_TAGS = new Set(['strong', 'em', 'u', 's', 'b', 'i'])
 
 const ooxmlParser = new XMLParser({
   ignoreAttributes: false,
@@ -260,32 +263,140 @@ function firstSnippet(text: string, limit = FIRST_LINE_LIMIT): string {
   return trimmed.length > limit ? trimmed.slice(0, limit) + '…' : trimmed
 }
 
-function extractTitle(html: string, fallback: string): string {
+function clampTitle(text: string): string {
+  return text.length > TITLE_FALLBACK_LIMIT
+    ? text.slice(0, TITLE_FALLBACK_LIMIT) + '…'
+    : text
+}
+
+/** Extract `style="text-align:X"` from a paragraph, or null if unset. */
+function paragraphAlignment($p: ReturnType<cheerio.CheerioAPI>): string | null {
+  const style = $p.attr('style') ?? ''
+  const m = style.match(/text-align:\s*([a-z]+)/i)
+  return m ? m[1]!.toLowerCase() : null
+}
+
+/** Returns the lowercased inline-formatting tag name if the paragraph's
+ *  meaningful content is wrapped entirely in exactly one such tag (e.g.
+ *  `<p><strong>...</strong></p>`). Mixed content returns null. */
+function paragraphInlineWrapper(
+  $p: ReturnType<cheerio.CheerioAPI>,
+  $: cheerio.CheerioAPI,
+): string | null {
+  const meaningful = $p.contents().filter((_idx, n) => {
+    if (n.type === 'text') return ($(n).text() ?? '').trim().length > 0
+    return n.type === 'tag'
+  })
+  if (meaningful.length !== 1) return null
+  const child = meaningful[0]
+  if (!child || child.type !== 'tag') return null
+  const tag = (child as unknown as { tagName?: string }).tagName?.toLowerCase()
+  if (!tag || !INLINE_WRAPPER_TAGS.has(tag)) return null
+  return tag
+}
+
+interface TitleDetection {
+  /** Default display title with em-dash separator. The wizard can re-derive
+   *  using `structure` if the user picks a different separator. */
+  title: string
+  /** Structured detection metadata. Present whenever the title came from a
+   *  heading or a recognizable chapter-marker paragraph. Absent when we
+   *  fell back to "first <p>" because the paragraph is real body content
+   *  the user shouldn't be able to strip. */
+  structure?: {
+    label: string
+    subtitle?: string
+  }
+  /** Body HTML with the title source paragraphs (heading, chapter marker,
+   *  combined subtitle) removed. Surrounding empty paragraphs are kept so
+   *  vertical spacing survives. Only present when `structure` is set. */
+  htmlWithoutTitle?: string
+}
+
+function extractTitleAndBody(html: string, fallback: string): TitleDetection {
   const $ = cheerio.load(`<div id="root">${html}</div>`, null, false)
   const root = $('#root')
 
+  // Heading → most reliable signal. Strip the heading element from the body
+  // since the title field will hold it; users who want it as part of the
+  // body too can toggle that off in the wizard.
   for (const tag of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']) {
-    const el = root.find(tag).first()
-    if (el.length > 0) {
-      const text = el.text().trim()
-      if (text) return text.length > TITLE_FALLBACK_LIMIT
-        ? text.slice(0, TITLE_FALLBACK_LIMIT) + '…'
-        : text
+    const $h = root.find(tag).first()
+    if ($h.length > 0) {
+      const text = $h.text().trim()
+      if (text) {
+        const clamped = clampTitle(text)
+        $h.remove()
+        return {
+          title: clamped,
+          structure: { label: text },
+          htmlWithoutTitle: root.html() ?? html,
+        }
+      }
     }
   }
 
-  // Now that empty paragraphs are preserved as vertical spacing, the first
-  // <p> in a segment is often blank. Skip those and grab the first <p>
-  // whose text content is non-empty.
-  const firstP = root.find('p').filter((_idx, el) => $(el).text().trim().length > 0).first()
-  if (firstP.length > 0) {
-    const text = firstP.text().trim()
-    if (text) return text.length > TITLE_FALLBACK_LIMIT
-      ? text.slice(0, TITLE_FALLBACK_LIMIT) + '…'
-      : text
+  // Empty paragraphs are now preserved as vertical spacing, so the first
+  // <p> in a segment is often blank. Walk forward until we find one with text.
+  const paragraphs = root.find('p')
+  let titleIdx = -1
+  for (let i = 0; i < paragraphs.length; i++) {
+    if (paragraphs.eq(i).text().trim().length > 0) {
+      titleIdx = i
+      break
+    }
+  }
+  if (titleIdx === -1) return { title: fallback }
+
+  const $title = paragraphs.eq(titleIdx)
+  const titleText = $title.text().trim()
+
+  // Chapter-marker paragraph: maybe combine with the next paragraph as a
+  // subtitle. Strict match — both alignment and inline wrapper must align,
+  // and the subtitle must be short and not itself another chapter marker.
+  if (titleText.length <= CHAPTER_PARAGRAPH_MAX_LEN && CHAPTER_PARAGRAPH_RE.test(titleText)) {
+    let subText: string | null = null
+    let subIdx = -1
+    for (let i = titleIdx + 1; i < paragraphs.length; i++) {
+      const $sub = paragraphs.eq(i)
+      const candidate = $sub.text().trim()
+      if (candidate.length === 0) continue
+      // First non-empty after the title decides — don't peek further.
+      if (candidate.length > SUBTITLE_MAX_LEN) break
+      if (CHAPTER_PARAGRAPH_RE.test(candidate)) break
+      if (paragraphAlignment($title) !== paragraphAlignment($sub)) break
+      const wrap = paragraphInlineWrapper($title, $)
+      if (wrap === null || wrap !== paragraphInlineWrapper($sub, $)) break
+      subText = candidate
+      subIdx = i
+      break
+    }
+
+    if (subText !== null && subIdx >= 0) {
+      const combined = clampTitle(`${titleText}${TITLE_SEPARATOR}${subText}`)
+      paragraphs.eq(subIdx).remove()
+      $title.remove()
+      return {
+        title: combined,
+        structure: { label: titleText, subtitle: subText },
+        htmlWithoutTitle: root.html() ?? html,
+      }
+    }
+
+    // Chapter marker alone, no subtitle.
+    $title.remove()
+    return {
+      title: clampTitle(titleText),
+      structure: { label: titleText },
+      htmlWithoutTitle: root.html() ?? html,
+    }
   }
 
-  return fallback
+  // First non-empty <p> doesn't look like a chapter marker — treat its text
+  // as the title but DON'T strip it from the body. It's real content the
+  // user probably wants kept; the wizard hides the strip toggle when
+  // structure is absent.
+  return { title: clampTitle(titleText) }
 }
 
 /** Split rendered HTML on the page-break markers we injected via transformDocument. */
@@ -583,12 +694,15 @@ export async function parseDocx(
       return true
     }).first()
     const firstLineSource = firstP.length > 0 ? firstP.text() : plainAll
+    const detection = extractTitleAndBody(sanitized, `Chapter ${i + 1}`)
     return {
       tempId: randomUUID(),
-      suggestedTitle: extractTitle(sanitized, `Chapter ${i + 1}`),
+      suggestedTitle: detection.title,
       html: sanitized,
       wordCount: countWordsFromText(plainAll),
       firstLine: firstSnippet(firstLineSource),
+      ...(detection.structure ? { titleStructure: detection.structure } : {}),
+      ...(detection.htmlWithoutTitle ? { htmlWithoutTitle: detection.htmlWithoutTitle } : {}),
     }
   })
 

--- a/apps/api/src/lib/import-parsers/index.ts
+++ b/apps/api/src/lib/import-parsers/index.ts
@@ -23,6 +23,20 @@ export interface ImportSegment {
   html: string
   wordCount: number
   firstLine: string
+  /** Structured title-detection metadata for parsers that can identify a
+   *  distinct title element (heading, chapter-marker paragraph, optionally
+   *  with a matching subtitle paragraph). Used by the wizard to recompute
+   *  the displayed title when the user picks a different separator and to
+   *  decide whether the "strip title from body" toggle should be available. */
+  titleStructure?: {
+    label: string
+    subtitle?: string
+  }
+  /** Body HTML with the title source paragraph(s) removed. Only set when
+   *  `titleStructure` is set. Surrounding empty paragraphs are kept so
+   *  vertical spacing stays intact. Used when the wizard's strip-from-body
+   *  option is enabled. */
+  htmlWithoutTitle?: string
 }
 
 export interface ImportWarning {

--- a/apps/api/src/lib/import-parsers/sanitize.ts
+++ b/apps/api/src/lib/import-parsers/sanitize.ts
@@ -23,12 +23,31 @@ const ALLOWED_ATTRIBUTES: sanitizeHtml.IOptions['allowedAttributes'] = {
   a: ['href', 'title', 'target', 'rel'],
   img: ['src', 'alt', 'title', 'width', 'height', 'data-external-src', 'data-import-error'],
   hr: ['class'],
+  p: ['style'],
+  h1: ['style'], h2: ['style'], h3: ['style'],
+  h4: ['style'], h5: ['style'], h6: ['style'],
+}
+
+// `style` is allowed on block-level text containers but locked to a single
+// property — text-align — with a fixed value set. This lets us carry
+// centered chapter titles and other Word-side alignment through to the
+// Tiptap text-align extension. Anything outside this allowlist (background,
+// font-size, expression(), …) is stripped.
+const ALLOWED_STYLES: sanitizeHtml.IOptions['allowedStyles'] = {
+  p: { 'text-align': [/^(left|center|right|justify)$/] },
+  h1: { 'text-align': [/^(left|center|right|justify)$/] },
+  h2: { 'text-align': [/^(left|center|right|justify)$/] },
+  h3: { 'text-align': [/^(left|center|right|justify)$/] },
+  h4: { 'text-align': [/^(left|center|right|justify)$/] },
+  h5: { 'text-align': [/^(left|center|right|justify)$/] },
+  h6: { 'text-align': [/^(left|center|right|justify)$/] },
 }
 
 export function sanitizeImportedHtml(html: string): string {
   return sanitizeHtml(html, {
     allowedTags: ALLOWED_TAGS,
     allowedAttributes: ALLOWED_ATTRIBUTES,
+    allowedStyles: ALLOWED_STYLES,
     allowedSchemes: ['http', 'https', 'mailto'],
     allowedSchemesByTag: {
       img: ['http', 'https', 'data'],

--- a/apps/shell/src/app/projects/[projectId]/components/dashboard/import/ImportWizard.tsx
+++ b/apps/shell/src/app/projects/[projectId]/components/dashboard/import/ImportWizard.tsx
@@ -16,7 +16,20 @@ interface Segment {
   html: string
   wordCount: number
   firstLine: string
+  titleStructure?: {
+    label: string
+    subtitle?: string
+  }
+  htmlWithoutTitle?: string
 }
+
+type TitleSeparator = ' — ' | ' - ' | ': ' | ''
+const SEPARATOR_OPTIONS: Array<{ value: TitleSeparator; label: string; example: string }> = [
+  { value: ' — ', label: 'Em-dash', example: 'Chapter One — Subtitle' },
+  { value: ' - ', label: 'Hyphen', example: 'Chapter One - Subtitle' },
+  { value: ': ', label: 'Colon', example: 'Chapter One: Subtitle' },
+  { value: '', label: 'Label only', example: 'Chapter One' },
+]
 
 interface Warning {
   code: string
@@ -99,6 +112,25 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
   const [containers, setContainers] = useState<ContainerOption[]>([])
   const [containerId, setContainerId] = useState<string>('')
   const [containersLoading, setContainersLoading] = useState(false)
+  // Title-format controls (visible only when at least one segment carries
+  // structured title detection). Default to em-dash to match what the
+  // server emits as suggestedTitle.
+  const [titleSeparator, setTitleSeparator] = useState<TitleSeparator>(' — ')
+  const [stripTitleFromBody, setStripTitleFromBody] = useState(false)
+  // Track which segments the user has typed into. Manually-edited titles
+  // are pinned and don't get overwritten when the title-format dropdown
+  // changes.
+  const [manuallyRenamed, setManuallyRenamed] = useState<Set<string>>(new Set())
+
+  /** Title displayed and committed for a segment, derived from the
+   *  current separator unless the user has typed into that row. */
+  const displayTitleFor = useCallback((s: Segment): string => {
+    if (manuallyRenamed.has(s.tempId)) return s.suggestedTitle
+    if (!s.titleStructure) return s.suggestedTitle
+    const { label, subtitle } = s.titleStructure
+    if (!subtitle || titleSeparator === '') return label
+    return `${label}${titleSeparator}${subtitle}`
+  }, [manuallyRenamed, titleSeparator])
 
   const loadContainers = useCallback(async () => {
     if (!apiToken) return
@@ -221,6 +253,12 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
 
   const renameSegment = (tempId: string, title: string) => {
     setEditedSegments(prev => prev.map(s => s.tempId === tempId ? { ...s, suggestedTitle: title } : s))
+    setManuallyRenamed(prev => {
+      if (prev.has(tempId)) return prev
+      const next = new Set(prev)
+      next.add(tempId)
+      return next
+    })
   }
 
   const discardSegment = (tempId: string) => {
@@ -276,8 +314,8 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
           projectId,
           containerId,
           segments: editedSegments.map(s => ({
-            title: s.suggestedTitle.trim() || 'Untitled chapter',
-            html: s.html,
+            title: displayTitleFor(s).trim() || 'Untitled chapter',
+            html: stripTitleFromBody && s.htmlWithoutTitle ? s.htmlWithoutTitle : s.html,
           })),
         }),
       })
@@ -361,6 +399,11 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
               containersLoading={containersLoading}
               containerId={containerId}
               setContainerId={setContainerId}
+              titleSeparator={titleSeparator}
+              setTitleSeparator={setTitleSeparator}
+              stripTitleFromBody={stripTitleFromBody}
+              setStripTitleFromBody={setStripTitleFromBody}
+              displayTitleFor={displayTitleFor}
               onRename={renameSegment}
               onDiscard={discardSegment}
               onMergeNext={mergeWithNext}
@@ -495,6 +538,11 @@ interface PreviewStepProps {
   containersLoading: boolean
   containerId: string
   setContainerId: (id: string) => void
+  titleSeparator: TitleSeparator
+  setTitleSeparator: (sep: TitleSeparator) => void
+  stripTitleFromBody: boolean
+  setStripTitleFromBody: (b: boolean) => void
+  displayTitleFor: (s: Segment) => string
   onRename: (tempId: string, title: string) => void
   onDiscard: (tempId: string) => void
   onMergeNext: (tempId: string) => void
@@ -504,8 +552,16 @@ interface PreviewStepProps {
 function PreviewStep({
   segments, warnings, sourceFormat,
   containers, containersLoading, containerId, setContainerId,
+  titleSeparator, setTitleSeparator,
+  stripTitleFromBody, setStripTitleFromBody,
+  displayTitleFor,
   onRename, onDiscard, onMergeNext, onMove,
 }: PreviewStepProps) {
+  // Title-format options are only meaningful when at least one segment
+  // carries structured title detection — otherwise the dropdown has no
+  // visible effect.
+  const hasStructuredTitles = segments.some(s => s.titleStructure)
+  const hasStripableSegments = segments.some(s => s.htmlWithoutTitle)
   return (
     <div className="space-y-4">
       {/* Warnings */}
@@ -539,6 +595,41 @@ function PreviewStep({
           ))}
         </select>
       </div>
+
+      {/* Title-format options — only meaningful when the parser surfaced
+          structured title detection (e.g. docx with chapter-marker /
+          subtitle combine). Hidden for plain text / markdown imports. */}
+      {hasStructuredTitles && (
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white/40 dark:bg-gray-800/40 p-3 space-y-2">
+          <div className="flex items-center gap-3 flex-wrap">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+              Title format:
+            </label>
+            <select
+              value={titleSeparator}
+              onChange={(e) => setTitleSeparator(e.target.value as TitleSeparator)}
+              className="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 cursor-pointer"
+            >
+              {SEPARATOR_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label} ({opt.example})
+                </option>
+              ))}
+            </select>
+          </div>
+          {hasStripableSegments && (
+            <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={stripTitleFromBody}
+                onChange={(e) => setStripTitleFromBody(e.target.checked)}
+                className="rounded border-gray-300 dark:border-gray-600 cursor-pointer"
+              />
+              <span>Remove title from chapter body (keep only as metadata)</span>
+            </label>
+          )}
+        </div>
+      )}
 
       <p className="text-xs text-gray-500 dark:text-gray-400">
         Detected format: <code className="font-mono">{sourceFormat}</code>. Rename, reorder,
@@ -578,7 +669,7 @@ function PreviewStep({
 
               <div className="flex-1 min-w-0">
                 <input
-                  value={s.suggestedTitle}
+                  value={displayTitleFor(s)}
                   onChange={(e) => onRename(s.tempId, e.target.value)}
                   className="w-full px-2 py-1 text-sm font-medium bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded text-gray-900 dark:text-gray-100"
                 />

--- a/bobbins/manuscript/package.json
+++ b/bobbins/manuscript/package.json
@@ -28,6 +28,7 @@
     "@tiptap/extension-character-count": "^3.6.2",
     "@tiptap/extension-image": "^3.20.0",
     "@tiptap/extension-placeholder": "^3.6.2",
+    "@tiptap/extension-text-align": "^3.23.6",
     "@tiptap/pm": "^3.6.2",
     "@tiptap/react": "^3.6.2",
     "@tiptap/starter-kit": "^3.6.2"

--- a/bobbins/manuscript/src/views/editor.tsx
+++ b/bobbins/manuscript/src/views/editor.tsx
@@ -6,6 +6,7 @@ import type { Editor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import CharacterCount from '@tiptap/extension-character-count'
+import TextAlign from '@tiptap/extension-text-align'
 import { ImageUpload } from '../extensions/image-upload'
 import { EntityHighlight } from '../extensions/entity-highlight'
 import type { EntityEntry } from '../extensions/entity-highlight'
@@ -494,6 +495,14 @@ export default function EditorView({ sdk, projectId, entityType, entityId, metad
         placeholder: 'Start writing...'
       }),
       CharacterCount,
+      // Preserves `text-align` on imported paragraphs/headings (centered
+      // chapter titles, etc.). Stored as inline style on the node so the
+      // round-trip through the editor is lossless.
+      TextAlign.configure({
+        types: ['heading', 'paragraph'],
+        alignments: ['left', 'center', 'right', 'justify'],
+        defaultAlignment: 'left',
+      }),
       ImageUpload.configure({
         sdk,
         projectId,

--- a/bun.lock
+++ b/bun.lock
@@ -369,6 +369,7 @@
         "@tiptap/extension-character-count": "^3.6.2",
         "@tiptap/extension-image": "^3.20.0",
         "@tiptap/extension-placeholder": "^3.6.2",
+        "@tiptap/extension-text-align": "^3.23.6",
         "@tiptap/pm": "^3.6.2",
         "@tiptap/react": "^3.6.2",
         "@tiptap/starter-kit": "^3.6.2",
@@ -1325,6 +1326,8 @@
     "@tiptap/extension-strike": ["@tiptap/extension-strike@3.20.0", "", { "peerDependencies": { "@tiptap/core": "^3.20.0" } }, "sha512-0vcTZRRAiDfon3VM1mHBr9EFmTkkUXMhm0Xtdtn0bGe+sIqufyi+hUYTEw93EQOD9XNsPkrud6jzQNYpX2H3AQ=="],
 
     "@tiptap/extension-text": ["@tiptap/extension-text@3.20.0", "", { "peerDependencies": { "@tiptap/core": "^3.20.0" } }, "sha512-tf8bE8tSaOEWabCzPm71xwiUhyMFKqY9jkP5af3Kr1/F45jzZFIQAYZooHI/+zCHRrgJ99MQHKHe1ZNvODrKHQ=="],
+
+    "@tiptap/extension-text-align": ["@tiptap/extension-text-align@3.23.6", "", { "peerDependencies": { "@tiptap/core": "3.23.6" } }, "sha512-pE+gDmvnrSMWHADDnDSzaO7YUi9kOywQkyrqZ9bEPLddZred7ICoJ4NtD2DqLjDSur+HijaJuByResWb78c6FA=="],
 
     "@tiptap/extension-underline": ["@tiptap/extension-underline@3.20.0", "", { "peerDependencies": { "@tiptap/core": "^3.20.0" } }, "sha512-LzNXuy2jwR/y+ymoUqC72TiGzbOCjioIjsDu0MNYpHuHqTWPK5aV9Mh0nbZcYFy/7fPlV1q0W139EbJeYBZEAQ=="],
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -872,6 +872,17 @@ export interface ImportSegment {
   html: string
   wordCount: number
   firstLine: string
+  /** Structured title-detection metadata. Currently emitted by the docx
+   *  parser when a chapter-marker paragraph is recognized; absent for
+   *  plain text / markdown / formats without an explicit title element. */
+  titleStructure?: {
+    label: string
+    subtitle?: string
+  }
+  /** Body HTML with the title source paragraph(s) removed. Only present
+   *  when `titleStructure` is set. Use this when the user wants the
+   *  chapter title kept only as metadata and not duplicated in the body. */
+  htmlWithoutTitle?: string
 }
 
 export interface ImportWarning {


### PR DESCRIPTION
## Summary

Fixes the formatting issues users hit when importing real Word manuscripts and adds wizard controls so authors can tune the chapter-title shape and decide whether the title text stays in the body.

### Empty paragraphs + paragraph alignment (original scope)

- **Empty paragraphs were dropped.** Mammoth strips `<w:p>` with no runs by default; authors use these as vertical spacing around system-text blocks, between chapter title and first body paragraph, etc. On a 947 KB real manuscript that meant **2,155 paragraphs lost per import**. Pass `ignoreEmptyParagraphs: false` to mammoth and they survive.
- **Centered paragraphs lost their alignment.** Mammoth's `transformDocument` exposes `paragraph.alignment` but never emits anything for it. Same manuscript: **1,523 paragraphs** (chapter titles, system-text blocks) were rendering left-aligned. Inject an alignment-marker text run from `transformDocument`, then strip it in a cheerio post-pass and write a `text-align` inline style on the enclosing `<p>` / `<h*>`.
- **Tiptap stripped any alignment we sent.** Without `@tiptap/extension-text-align`, the manuscript editor's HTML parser drops `text-align` styles on parse. Added and configured for `paragraph` + `heading` types.
- **Sanitizer was too narrow.** `allowedAttributes.style` is now opened on `<p>` and `<h1>`-`<h6>`, locked via `allowedStyles` to `text-align: left|center|right|justify`. Anything else (background, font-size, expression()) is still dropped.

### Chapter title + subtitle combining (added in response to feedback)

The docx parser now detects a chapter-marker paragraph followed by a matching subtitle paragraph and combines them into one title:

```
<p style="text-align:center"><strong>Chapter One</strong></p>
<p style="text-align:center"><strong>Sleeping In Can Literally Get You Killed</strong></p>
        ↓
"Chapter One — Sleeping In Can Literally Get You Killed"
```

Strict match: both paragraphs must share alignment AND the same inline-wrapper tag, the subtitle must be short (≤ 120 chars), and it can't itself be another chapter marker. Authors who happen to format epigraphs differently (italic, different alignment) won't get false positives.

The parser returns the structured detection so the client can rework presentation:
- `titleStructure: { label, subtitle? }` — for separator changes
- `htmlWithoutTitle` — body HTML with the title paragraph(s) removed (empty spacing paragraphs around them are kept)

### Wizard options (added in response to feedback)

When at least one segment has structured detection, the preview step shows two controls:

- **Title format** dropdown — Em-dash (default), Hyphen, Colon, or "Label only" (just "Chapter One"). Changing it re-derives titles for segments the user hasn't typed into.
- **Remove title from chapter body** checkbox — swaps `html` for `htmlWithoutTitle` at commit time, so the title text shows only as chapter metadata.

Manual edits are pinned via a `manuallyRenamed` Set so changing the separator doesn't blow them away. Plain text / markdown / formats without structured detection don't see the controls (no UI noise where they wouldn't apply).

## Test plan

- [x] `bun run typecheck` — 48 tasks clean
- [x] `bun run lint` / `bun run lint:bobbins` — clean
- [x] Full pre-commit pipeline (lockfile / schema drift / lint / bobbin lint / vercel compat / Dockerfile workspaces / typecheck / build) — clean
- [x] End-to-end against a 947 KB real manuscript: 102 segments, zero `STRUCTURE_GUESSED` warnings, centered chapter titles render as `<p style="text-align:center"><strong>…</strong></p>`, 2,155 empty paragraphs preserved, 1,523 alignments preserved, default em-dash separator produces "Chapter One — Sleeping In Can Literally Get You Killed" for all 101 chapters
- [ ] Manual: open an imported chapter and confirm system-text spacing visually matches the original Word doc
- [ ] Manual: edit and save a chapter with centered text — confirm the alignment survives the Tiptap round-trip
- [ ] Manual: in the import wizard, switch the title-format dropdown and confirm untouched chapter titles update; rename a chapter and confirm it stays after switching the dropdown again
- [ ] Manual: toggle "Remove title from chapter body" on; confirm the imported chapter's body starts at the first body paragraph (no duplicated chapter heading)

## A note for affected users

Existing imports done before this lands stay as-is — the fix only applies to **new** imports. Anyone who hit this on a first attempt will want to delete the affected chapters and re-import after the deploy.
