### PR TITLE
import: container picker can create new or land at root

### DIFF
--- a/apps/api/src/lib/event-bus.ts
+++ b/apps/api/src/lib/event-bus.ts
@@ -167,7 +167,7 @@ export function importParseFailed(
 export function importCommitCompleted(
   projectId: string,
   userId: string,
-  containerId: string,
+  containerId: string | null,
   segmentCount: number,
   durationMs: number,
 ): DomainEvent {

--- a/apps/api/src/routes/import.ts
+++ b/apps/api/src/routes/import.ts
@@ -49,7 +49,9 @@ const ParseRequestSchema = z.object({
 
 const CommitRequestSchema = z.object({
   projectId: z.string().uuid('Invalid project ID format'),
-  containerId: z.string().uuid('Invalid container ID format'),
+  // Optional. Omit (or null) to land the chapters at root — i.e. with no
+  // container_id, so they show as top-level items in the manuscript outline.
+  containerId: z.string().uuid('Invalid container ID format').optional().nullable(),
   segments: z.array(z.object({
     title: z.string().min(1).max(500),
     html: z.string().max(2 * 1024 * 1024), // 2 MB per chapter is plenty
@@ -267,7 +269,7 @@ const importPlugin: FastifyPluginAsync = async (fastify) => {
   fastify.post<{
     Body: {
       projectId: string
-      containerId: string
+      containerId?: string | null
       segments: Array<{ title: string; html: string }>
     }
   }>('/import/commit', {
@@ -292,7 +294,8 @@ const importPlugin: FastifyPluginAsync = async (fastify) => {
 
     try {
       const body = CommitRequestSchema.parse(request.body)
-      const { projectId, containerId, segments } = body
+      const { projectId, segments } = body
+      const containerId = body.containerId ?? null
       const user = request.user!
       resolvedProjectId = projectId
       resolvedUserId = user.id
@@ -301,25 +304,29 @@ const importPlugin: FastifyPluginAsync = async (fastify) => {
       const hasAccess = await requireProjectOwnership(request, reply, projectId)
       if (!hasAccess) return
 
-      // Verify the container exists, lives in this project, and is a
-      // manuscript-bobbin container.
-      const [container] = await db
-        .select({ id: entities.id })
-        .from(entities)
-        .where(and(
-          eq(entities.id, containerId),
-          eq(entities.projectId, projectId),
-          eq(entities.bobbinId, 'manuscript'),
-          eq(entities.collectionName, 'containers'),
-        ))
-        .limit(1)
+      // Verify the container exists when supplied. A null containerId means
+      // "land the chapters at root with no container_id" — that's a legal
+      // shape in the manuscript bobbin (the outline panel renders such
+      // content as top-level items).
+      if (containerId !== null) {
+        const [container] = await db
+          .select({ id: entities.id })
+          .from(entities)
+          .where(and(
+            eq(entities.id, containerId),
+            eq(entities.projectId, projectId),
+            eq(entities.bobbinId, 'manuscript'),
+            eq(entities.collectionName, 'containers'),
+          ))
+          .limit(1)
 
-      if (!container) {
-        emitCommitFailure('IMPORT_CONTAINER_NOT_FOUND')
-        return reply.status(422).send({
-          error: 'Target container not found in this project',
-          code: 'IMPORT_CONTAINER_NOT_FOUND',
-        })
+        if (!container) {
+          emitCommitFailure('IMPORT_CONTAINER_NOT_FOUND')
+          return reply.status(422).send({
+            error: 'Target container not found in this project',
+            code: 'IMPORT_CONTAINER_NOT_FOUND',
+          })
+        }
       }
 
       // Resolve the content collection to its bobbin once (manuscript).
@@ -333,10 +340,18 @@ const importPlugin: FastifyPluginAsync = async (fastify) => {
         })
       }
 
-      // Find the current max order for this container so new chapters land
-      // at the end. Both camelCase and snake_case container keys are checked
-      // because legacy entity rows may use either shape (mirrors the same
-      // pattern in entities.ts deleteContainerCascade).
+      // Find the current max order for siblings so new chapters land at the
+      // end. When committing into a container, "siblings" are content items
+      // with the same container_id (both camelCase and snake_case keys are
+      // checked because legacy entity rows may use either shape — same
+      // pattern as deleteContainerCascade in entities.ts). When committing
+      // at root, siblings are content items with no container_id at all.
+      const siblingsFilter = containerId === null
+        ? sql`(${entities.entityData}->>'container_id' IS NULL
+            AND ${entities.entityData}->>'containerId' IS NULL)`
+        : sql`(${entities.entityData}->>'container_id' = ${containerId}
+            OR ${entities.entityData}->>'containerId' = ${containerId})`
+
       const [maxRow] = await db
         .select({
           maxOrder: sql<string | null>`
@@ -350,8 +365,7 @@ const importPlugin: FastifyPluginAsync = async (fastify) => {
         .where(and(
           eq(entities.projectId, projectId),
           eq(entities.collectionName, 'content'),
-          sql`(${entities.entityData}->>'container_id' = ${containerId}
-            OR ${entities.entityData}->>'containerId' = ${containerId})`,
+          siblingsFilter,
         ))
 
       const startingOrder = Number(maxRow?.maxOrder ?? 0)
@@ -367,7 +381,6 @@ const importPlugin: FastifyPluginAsync = async (fastify) => {
 
           const data: Record<string, any> = {
             title: seg.title,
-            container_id: containerId,
             type: 'scene',
             body: seg.html,
             order,
@@ -375,6 +388,9 @@ const importPlugin: FastifyPluginAsync = async (fastify) => {
             status: 'draft',
             created_at: now,
             updated_at: now,
+          }
+          if (containerId !== null) {
+            data.container_id = containerId
           }
 
           const insertValues: Record<string, any> = {

--- a/apps/shell/src/app/projects/[projectId]/components/dashboard/import/ImportWizard.tsx
+++ b/apps/shell/src/app/projects/[projectId]/components/dashboard/import/ImportWizard.tsx
@@ -31,6 +31,9 @@ const SEPARATOR_OPTIONS: Array<{ value: TitleSeparator; label: string; example: 
   { value: '', label: 'Label only', example: 'Chapter One' },
 ]
 
+const CONTAINER_NEW = '__new__'
+const CONTAINER_ROOT = '__root__'
+
 interface Warning {
   code: string
   message: string
@@ -110,7 +113,11 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
   const [phase, setPhase] = useState<Phase>({ kind: 'pick' })
   const [editedSegments, setEditedSegments] = useState<Segment[]>([])
   const [containers, setContainers] = useState<ContainerOption[]>([])
+  // `containerId` holds either an existing container's UUID or one of the
+  // sentinel values below. Sentinels are translated to real API arguments
+  // at commit time.
   const [containerId, setContainerId] = useState<string>('')
+  const [newContainerName, setNewContainerName] = useState<string>('Imported chapters')
   const [containersLoading, setContainersLoading] = useState(false)
   // Title-format controls (visible only when at least one segment carries
   // structured title detection). Default to em-dash to match what the
@@ -144,7 +151,13 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
         type: e.type || 'folder',
       }))
       setContainers(list)
-      if (list.length > 0) setContainerId(prev => prev || list[0]!.id)
+      if (list.length > 0) {
+        setContainerId(prev => prev || list[0]!.id)
+      } else {
+        // No existing containers — default to "Create new" so the user can
+        // proceed without bouncing out to the manuscript outline first.
+        setContainerId(prev => prev || CONTAINER_NEW)
+      }
     } catch {
       setContainers([])
     } finally {
@@ -303,8 +316,55 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
       setPhase({ kind: 'error', message: 'No segments left to commit', retryTo: 'preview' })
       return
     }
+    if (containerId === CONTAINER_NEW && newContainerName.trim().length === 0) {
+      setPhase({ kind: 'error', message: 'Give the new container a name', retryTo: 'preview' })
+      return
+    }
 
     setPhase({ kind: 'committing' })
+
+    // Resolve the container choice into the value the API expects:
+    //   - CONTAINER_ROOT → null  (chapters land at top level)
+    //   - CONTAINER_NEW  → create the container first, use its id
+    //   - any UUID       → use as-is
+    let effectiveContainerId: string | null
+    if (containerId === CONTAINER_ROOT) {
+      effectiveContainerId = null
+    } else if (containerId === CONTAINER_NEW) {
+      try {
+        const createRes = await apiFetch('/api/entities', apiToken, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            collection: 'containers',
+            projectId,
+            data: {
+              title: newContainerName.trim(),
+              type: 'chapter',
+              order: (containers.length + 1) * 100,
+            },
+          }),
+        })
+        if (!createRes.ok) {
+          const err = await createRes.json().catch(() => ({ error: 'Container create failed' }))
+          throw new Error(err.error || `Failed to create container (${createRes.status})`)
+        }
+        const created = await createRes.json()
+        if (typeof created?.id !== 'string') {
+          throw new Error('Container creation returned no id')
+        }
+        effectiveContainerId = created.id
+      } catch (err) {
+        setPhase({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Could not create container',
+          retryTo: 'preview',
+        })
+        return
+      }
+    } else {
+      effectiveContainerId = containerId
+    }
 
     try {
       const res = await apiFetch('/api/import/commit', apiToken, {
@@ -312,7 +372,7 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           projectId,
-          containerId,
+          containerId: effectiveContainerId,
           segments: editedSegments.map(s => ({
             title: displayTitleFor(s).trim() || 'Untitled chapter',
             html: stripTitleFromBody && s.htmlWithoutTitle ? s.htmlWithoutTitle : s.html,
@@ -399,6 +459,8 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
               containersLoading={containersLoading}
               containerId={containerId}
               setContainerId={setContainerId}
+              newContainerName={newContainerName}
+              setNewContainerName={setNewContainerName}
               titleSeparator={titleSeparator}
               setTitleSeparator={setTitleSeparator}
               stripTitleFromBody={stripTitleFromBody}
@@ -447,7 +509,11 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
                 </button>
                 <button
                   onClick={commit}
-                  disabled={editedSegments.length === 0 || !containerId}
+                  disabled={
+                    editedSegments.length === 0
+                    || !containerId
+                    || (containerId === CONTAINER_NEW && newContainerName.trim().length === 0)
+                  }
                   className="px-4 py-2 text-sm font-medium bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                 >
                   Import {editedSegments.length} chapter{editedSegments.length === 1 ? '' : 's'}
@@ -538,6 +604,8 @@ interface PreviewStepProps {
   containersLoading: boolean
   containerId: string
   setContainerId: (id: string) => void
+  newContainerName: string
+  setNewContainerName: (name: string) => void
   titleSeparator: TitleSeparator
   setTitleSeparator: (sep: TitleSeparator) => void
   stripTitleFromBody: boolean
@@ -552,6 +620,7 @@ interface PreviewStepProps {
 function PreviewStep({
   segments, warnings, sourceFormat,
   containers, containersLoading, containerId, setContainerId,
+  newContainerName, setNewContainerName,
   titleSeparator, setTitleSeparator,
   stripTitleFromBody, setStripTitleFromBody,
   displayTitleFor,
@@ -576,24 +645,49 @@ function PreviewStep({
       )}
 
       {/* Container picker */}
-      <div className="flex items-center gap-3">
-        <label className="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
-          Add to container:
-        </label>
-        <select
-          value={containerId}
-          onChange={(e) => setContainerId(e.target.value)}
-          disabled={containersLoading || containers.length === 0}
-          className="flex-1 px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 disabled:opacity-50 cursor-pointer"
-        >
-          {containersLoading && <option>Loading containers…</option>}
-          {!containersLoading && containers.length === 0 && (
-            <option value="">No containers — create one in the manuscript outline first</option>
-          )}
-          {containers.map(c => (
-            <option key={c.id} value={c.id}>{c.title} ({c.type})</option>
-          ))}
-        </select>
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <label className="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+            Add to container:
+          </label>
+          <select
+            value={containerId}
+            onChange={(e) => setContainerId(e.target.value)}
+            disabled={containersLoading}
+            className="flex-1 px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 disabled:opacity-50 cursor-pointer"
+          >
+            {containersLoading && <option>Loading containers…</option>}
+            {!containersLoading && (
+              <>
+                {containers.length > 0 && (
+                  <optgroup label="Existing containers">
+                    {containers.map(c => (
+                      <option key={c.id} value={c.id}>{c.title} ({c.type})</option>
+                    ))}
+                  </optgroup>
+                )}
+                <optgroup label={containers.length > 0 ? 'Or…' : 'Choose where the chapters land'}>
+                  <option value={CONTAINER_NEW}>+ Create new container…</option>
+                  <option value={CONTAINER_ROOT}>↑ Root (no container)</option>
+                </optgroup>
+              </>
+            )}
+          </select>
+        </div>
+        {containerId === CONTAINER_NEW && (
+          <div className="flex items-center gap-3 pl-[125px]">
+            <label className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+              New container name:
+            </label>
+            <input
+              value={newContainerName}
+              onChange={(e) => setNewContainerName(e.target.value)}
+              placeholder="e.g. Book One"
+              className="flex-1 px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+              autoFocus
+            />
+          </div>
+        )}
       </div>
 
       {/* Title-format options — only meaningful when the parser surfaced


### PR DESCRIPTION
## Summary

The "Add to container" dropdown in the import wizard previously listed only existing containers and gave up with a "create one in the manuscript outline first" prompt when none existed. Authors hit this on the very first import after creating a project, when the only available container is the auto-seeded "Chapter 1" they didn't actually ask for.

Two new options join the dropdown:

| Option | Behavior |
|---|---|
| **+ Create new container…** | Inline name input appears below the dropdown (default: "Imported chapters"). The wizard creates the container via `POST /api/entities` before committing, then uses the returned id. Commit button is disabled while the name is blank. |
| **↑ Root (no container)** | The wizard sends `containerId: null` on commit. New chapters land as top-level items in the manuscript outline (the panel already supports this via the `!c.container_id` filter in `navigation.tsx`). |

If a project has no containers at all, the dropdown now defaults to "Create new container" so users can proceed inline without bouncing out to the manuscript outline.

## What changed

- **`apps/api/src/routes/import.ts`**: `containerId` in `CommitRequestSchema` is now `optional().nullable()`. Container existence check is skipped when null. The sibling-order query uses `container_id IS NULL` when committing at root and the container-equality predicate otherwise. Inserted entity data omits `container_id` entirely when null (cleaner than null in JSONB).
- **`apps/api/src/lib/event-bus.ts`**: `importCommitCompleted` accepts `containerId: string | null` so telemetry payloads carry the root case explicitly.
- **`ImportWizard.tsx`**: new `CONTAINER_NEW` / `CONTAINER_ROOT` sentinels in the dropdown (rendered in `<optgroup>` sections), a conditional `newContainerName` input below the select, commit button disabled when "Create new" is selected with an empty name, and a defensive default-to-`CONTAINER_NEW` when the project has no containers yet.

## Test plan

- [x] `bun run typecheck` — 48 tasks clean
- [x] `bun run lint` / `bun run lint:bobbins` — clean
- [x] Full pre-commit pipeline (lockfile / schema drift / lint / bobbin lint / vercel compat / Dockerfile workspaces / typecheck / build) — clean
- [ ] Manual: import into an existing container — same behavior as before
- [ ] Manual: import into a brand-new container — confirm the new container shows up in the outline at the end of the existing list, with the imported chapters underneath it
- [ ] Manual: import to Root — confirm chapters appear at the top level of the manuscript outline, not under any container
- [ ] Manual: import into a project that has zero containers — confirm the dropdown defaults to "Create new container" and works inline

## Note

PM2 restarted locally so the new wizard is live on `bobbinry.utaboshi.com`. Existing project IDs are unaffected by the change.
