### PR TITLE
import: default container picker to "Root (no container)"

### DIFF
--- a/apps/shell/src/app/projects/[projectId]/components/dashboard/import/ImportWizard.tsx
+++ b/apps/shell/src/app/projects/[projectId]/components/dashboard/import/ImportWizard.tsx
@@ -151,13 +151,12 @@ export function ImportWizard({ projectId, onClose, onComplete }: ImportWizardPro
         type: e.type || 'folder',
       }))
       setContainers(list)
-      if (list.length > 0) {
-        setContainerId(prev => prev || list[0]!.id)
-      } else {
-        // No existing containers — default to "Create new" so the user can
-        // proceed without bouncing out to the manuscript outline first.
-        setContainerId(prev => prev || CONTAINER_NEW)
-      }
+      // Default to Root regardless of how many containers exist. The most
+      // common import flow is "new project → first import" where the only
+      // pre-existing container is the auto-seeded "Chapter 1", which the
+      // user almost certainly didn't intend as the import target. Users
+      // who do want a specific container can pick from the dropdown.
+      setContainerId(prev => prev || CONTAINER_ROOT)
     } catch {
       setContainers([])
     } finally {


### PR DESCRIPTION
## Summary

The default selection in the wizard's "Add to container" dropdown was the first existing container, which on a new project is the auto-seeded "Chapter 1" — not what users expect when their typical flow is "create project → import → accept". Switch the default to Root for all cases.

Users who do want chapters inside a specific container still pick from the same dropdown; the available options are unchanged.

## Test plan

- [x] Typecheck + lint clean
- [x] Pre-commit pipeline (lockfile / schema drift / lint / bobbin lint / vercel compat / Dockerfile workspaces / typecheck / build) — clean
- [ ] Manual: import on a freshly-created project — confirm chapters land at root, not under "Chapter 1"
- [ ] Manual: import on a project with multiple existing containers — confirm default is still Root but the dropdown still lists each container as a selectable option