### PR TITLE
fix(shell): pin Vercel install to --frozen-lockfile

### DIFF
--- a/apps/shell/vercel.json
+++ b/apps/shell/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "cd ../.. && rm -rf node_modules && bun install --frozen-lockfile",
   "buildCommand": "cd ../.. && bun run build --filter=shell"
 }


### PR DESCRIPTION
Fixes the failing Vercel deploys after #60. Vercel's default non-frozen `bun install` + restored build cache left both `prosemirror-model@1.25.4` (cached) and `1.25.8` (new lock) in node_modules, so the shell build's tsc saw two copies and failed in `@bobbinry/feedback`. CI passed because it uses `--frozen-lockfile`.

This pins Vercel's install to `bun install --frozen-lockfile` so it installs exactly the committed lock. **The preview deploy on this PR validates the fix** — if it goes green, the cache-dup is resolved before this reaches prod.